### PR TITLE
Add command-line option for specifying browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ server.listen(argv.port, () => {
   console.log(`listening ${argv.port} ...`);
 
   argv._.forEach(file =>
-    open(`http://localhost:${argv.port}/${file}`).catch(() => {})
+    open(`http://localhost:${argv.port}/${file}`,
+        {app: `${argv.browser}`}).catch(() => {})
   );
 });

--- a/src/argv.js
+++ b/src/argv.js
@@ -1,9 +1,15 @@
 "use strict";
 
+const DEFAULT_BROWSER = "firefox";
 const DEFAULT_PORT = 6060;
 
 module.exports = require("yargs")
   .usage("Usage: $0 [options] [file]")
+  .option("b", {
+    alias: "browser",
+    default: DEFAULT_BROWSER,
+    describe: "Set browser to use"
+  })
   .option("p", {
     alias: "port",
     default: DEFAULT_PORT,


### PR DESCRIPTION
This PR lets one specify the browser use by pen for opening rendered files so that one does not have to alter one's default browser.